### PR TITLE
Adding NAPTR (Enum) and Forking capabilities to provide concurrent query support

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,11 @@
 Revision history for Stanford::DNSserver
 
+1.3.0	Fri Feb 10 16:10:44 PDT 2017
+	- Added NAPTR (Enum) Capability
+	- Added forking to support handling requests simultaneously.
+	- Implemented on https://www.certic.info e164enum.eu 
+	- Modification: Stefan Ćertić
+
 1.2.0   Mon Sep 22 14:19:13 PDT 2003
 	 - Close all unnecessary sockets in TCP child.
 	 - wait(2) instead of waitpid(2) to stop TCP hangs.

--- a/DNS.pm
+++ b/DNS.pm
@@ -257,7 +257,8 @@ sub rr_TXT {
 # Added Naptr
 
 sub rr_NAPTR {
-    # Adding mcc mnc for NAPTR / SPN. More info about enum at https://www.certic.info
+    # mcc mnc for NAPTR / SPN. More info about enum at https://www.certic.info
+    # Adding NAPTR support. More info at Stefan Certic
     my $nap_mcc = shift;
     my $nap_mnc = shift;
     my $res;

--- a/DNS.pm
+++ b/DNS.pm
@@ -257,6 +257,7 @@ sub rr_TXT {
 # Added Naptr
 
 sub rr_NAPTR {
+    # Adding mcc mnc for NAPTR / SPN. More info about enum at https://www.certic.info
     my $nap_mcc = shift;
     my $nap_mnc = shift;
     my $res;

--- a/DNS.pm
+++ b/DNS.pm
@@ -29,7 +29,7 @@ use Exporter;
   %Op2A %Err2A %Type2A %Class2A
 
   rr_A rr_CNAME rr_NS rr_PTR rr_NULL rr_MX rr_SOA rr_TXT rr_HINFO rr_RP
-  rr_WKS rr_LOC rr_LOC_raw rr_SRV
+  rr_WKS rr_LOC rr_LOC_raw rr_SRV rr_NAPTR
 
   dns_answer dns_simple_dname dn_expand
 
@@ -253,6 +253,53 @@ sub rr_TXT {
     }
     $res;
 }
+
+# Added Naptr
+
+sub rr_NAPTR {
+    my $nap_mcc = shift;
+    my $nap_mnc = shift;
+    my $res;
+    #my $res = '10 100 "u" "E2U+pstn:tel" "!^(.*)$!tel:\\1\;spn=22003\;mcc=220\;mnc=03!" .';
+        
+    $res .= pack("n2", "10", "100");
+                   
+    $res .= pack("C", length "u");
+    $res .= "u";
+                       
+    $res .= pack("C", length "E2U+pstn:tel");
+    $res .= "E2U+pstn:tel";
+                        
+    $res .= pack("C", length "!^(.*)\$!tel:\\1;spn=$nap_mcc$nap_mnc;mcc=$nap_mcc;mnc=$nap_mnc!");
+    $res .= "!^(.*)\$!tel:\\1;spn=$nap_mcc$nap_mnc;mcc=$nap_mcc;mnc=$nap_mnc!";
+
+    #$res .= "0";
+    $res .= pack("C", "0" );
+    #$res .= "1";
+                      
+    #$res .= $self->_name2wire ($self->{"replacement"});
+                     
+
+
+
+    #$res .= pack("n2", "10", "100"); 
+    #$res .= pack("C", length("u"));
+    #$res .= "u"; 
+    #$res .= pack("C", length("E2U+pstn:tel")); 
+    #$res .= "E2U+pstn:tel"; 
+    #$res .= pack("C", length("!^(.*)\$!tel:\\1;spn=22003;mcc=220;mnc=03!"));
+    #$res .= "!^(.*)\$!tel:\\1;spn=22003;mcc=220;mnc=03!"; 
+    #$res .= "1"; 
+    #return pack('Ca*Ca*', 1, "1", 1, "1");
+
+    #for (my $i = 0; $i < length $text; $i += 255) {
+    #    my $t = substr($text, $i, 255);
+    #    $res .= pack('Ca*', length $t, $t);
+    #}
+    return $res;
+}
+
+
 
 sub rr_HINFO {
     my ($cpu, $os) = @_;

--- a/DNSserver.pm
+++ b/DNSserver.pm
@@ -60,7 +60,8 @@ sub answer_queries {
     my $UDP = getprotobyname('udp') or $self->abort("can't get udp: $!");
     my $TCP = getprotobyname('tcp') or $self->abort("can't get tcp: $!");
 
-# Forking
+# Forking - extending to support concurent requests while matching them.
+# Added by Stefan Certic, More info at https://www.certic.info
 
     while (1) { &{$self->{loopfunc}} if $run;
 

--- a/README
+++ b/README
@@ -48,3 +48,5 @@ COPYRIGHT AND LICENSE
   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
+  @2017 Stefan Ćertić Added Enum (NAPTR) Capabilities and Forking to handle requests
+  simultaneously. Implemented on: https://www.certic.info http://e164enum.eu

--- a/example.pl
+++ b/example.pl
@@ -14,7 +14,7 @@ $ns = new
 #		       port      =>          5300,
 		       defttl    =>            60,
 		       debug     =>             1,
-		       daemon    =>          "no",
+		       daemon    =>          "yes",
 		       pidfile   => "example.pid",
 
 #		       chroot    =>    "/var/tmp",


### PR DESCRIPTION
- Added NAPTR (ENUM) records - used to return SPN (mcc / mnc)
- Added forking capability to handle multiple requests simultaneously
- [More about use case which is specific to telecom industry at Stefan Certic website](https://www.certic.info)